### PR TITLE
[PIPE-3468] Additional fields

### DIFF
--- a/src/processor/bugsnag_stackwalk_wrapper.cc
+++ b/src/processor/bugsnag_stackwalk_wrapper.cc
@@ -39,7 +39,7 @@ int getErrorReportingThreadIndex(const ProcessState& process_state) {
 }
 
 // strips the `FRAME_TRUST_` from the trust enum
-string getTrustWithoutPrefix(StackFrame::FrameTrust stackFrameTrust)  {
+string getFriendlyTrustValue(StackFrame::FrameTrust stackFrameTrust)  {
   string trust = "";
   switch(stackFrameTrust) {
     case StackFrame::FRAME_TRUST_NONE:
@@ -88,7 +88,7 @@ static Stacktrace getStack(int thread_num, const CallStack* stack)  {
     string returnAddress = HexString(frame->ReturnAddress());
     string symbolAddress = HexString(frame->function_base);
     string codeFile;
-    string trust = getTrustWithoutPrefix(frame->trust);
+    string trust = getFriendlyTrustValue(frame->trust);
 
     if (symbolAddress == "0x0") {
       symbolAddress = "";
@@ -233,38 +233,6 @@ WrappedModuleDetails GetModuleDetails(const char* minidump_filename) {
   }
 
   return result;
-}
-
-string getFrameTrust(StackFrame::FrameTrust frameTrust) {
-  string trust = "";
-  
-  switch(frameTrust) {
-    case StackFrame::FRAME_TRUST_NONE:
-      trust = "NONE";
-      break;
-    case StackFrame::FRAME_TRUST_SCAN:
-      trust = "SCAN";
-      break;
-    case StackFrame::FRAME_TRUST_CFI_SCAN:
-      trust = "CFI_SCAN";
-      break;
-    case StackFrame::FRAME_TRUST_FP:
-    trust = "FP";
-    break;
-    case StackFrame::FRAME_TRUST_CFI:
-    trust = "CFI";
-    break;
-    case StackFrame::FRAME_TRUST_PREWALKED:
-    trust = "PREWALKED";
-    break;
-    case StackFrame::FRAME_TRUST_CONTEXT:
-    trust = "CONTEXT";
-    break;
-    default:
-      break;
-  }
-
-  return trust;
 }
 
 // Gets a friendly version of a minidump processing failure reason

--- a/src/processor/bugsnag_stackwalk_wrapper.cc
+++ b/src/processor/bugsnag_stackwalk_wrapper.cc
@@ -38,6 +38,38 @@ int getErrorReportingThreadIndex(const ProcessState& process_state) {
   return index;
 }
 
+// strips the `FRAME_TRUST_` from the trust enum
+string getTrustWithoutPrefix(StackFrame::FrameTrust stackFrameTrust)  {
+  string trust = "";
+  switch(stackFrameTrust) {
+    case StackFrame::FRAME_TRUST_NONE:
+      trust = "NONE";
+      break;
+    case StackFrame::FRAME_TRUST_SCAN:
+      trust = "SCAN";
+      break;
+    case StackFrame::FRAME_TRUST_CFI_SCAN:
+      trust = "CFI_SCAN";
+      break;
+    case StackFrame::FRAME_TRUST_FP:
+      trust = "FP";
+      break;
+    case StackFrame::FRAME_TRUST_CFI:
+      trust = "CFI";
+      break;
+    case StackFrame::FRAME_TRUST_PREWALKED:
+      trust = "PREWALKED";
+      break;
+    case StackFrame::FRAME_TRUST_CONTEXT:
+      trust = "CONTEXT";
+      break;
+    default:
+      break;
+  }
+
+  return trust;
+}
+
 // Maps the stacktrace information from a minidump into our Stacktrace struct
 static Stacktrace getStack(int thread_num, const CallStack* stack)  {
   int frame_count = stack->frames()->size();
@@ -56,34 +88,7 @@ static Stacktrace getStack(int thread_num, const CallStack* stack)  {
     string returnAddress = HexString(frame->ReturnAddress());
     string symbolAddress = HexString(frame->function_base);
     string codeFile;
-    string trust = "";
-  
-    // TODO: Maybe split this into a function but when I try I get "use of undeclared identifier 'getFrameTrust'" when trying to build
-    switch(frame->trust) {
-      case StackFrame::FRAME_TRUST_NONE:
-        trust = "NONE";
-        break;
-      case StackFrame::FRAME_TRUST_SCAN:
-        trust = "SCAN";
-        break;
-      case StackFrame::FRAME_TRUST_CFI_SCAN:
-        trust = "CFI_SCAN";
-        break;
-      case StackFrame::FRAME_TRUST_FP:
-      trust = "FP";
-      break;
-      case StackFrame::FRAME_TRUST_CFI:
-      trust = "CFI";
-      break;
-      case StackFrame::FRAME_TRUST_PREWALKED:
-      trust = "PREWALKED";
-      break;
-      case StackFrame::FRAME_TRUST_CONTEXT:
-      trust = "CONTEXT";
-      break;
-      default:
-        break;
-    }
+    string trust = getTrustWithoutPrefix(frame->trust);
 
     if (symbolAddress == "0x0") {
       symbolAddress = "";

--- a/src/processor/bugsnag_stackwalk_wrapper.cc
+++ b/src/processor/bugsnag_stackwalk_wrapper.cc
@@ -48,28 +48,37 @@ static Stacktrace getStack(int thread_num, const CallStack* stack)  {
     const StackFrame* frame = stack->frames()->at(frame_index);
 
     string frameAddress = HexString(frame->instruction);
-    string returnAddress;
+    string method = frame->function_name;
     string loadAddress = "";
     string filename = "";
     string moduleId = "";
     string moduleName = "";
+    string returnAddress = HexString(frame->ReturnAddress());
+    string symbolAddress = HexString(frame->function_base);
+    string codeFile;
+
+    if (symbolAddress == "0x0") {
+      symbolAddress = "";
+    }
+
     if (frame->module) {
-      returnAddress = HexString(frame->ReturnAddress() - frame->module->base_address());
       loadAddress = HexString(frame->module->base_address());
       filename = frame->module->code_file();
       moduleId = frame->module->debug_identifier();
       moduleName = frame->module->debug_file();
-    } else {
-      returnAddress = HexString(frame->ReturnAddress());
+      codeFile = frame->module->code_file();
     }
     
     Stackframe f = {
       .filename = strdup(filename.c_str()),
-      .method = strdup(returnAddress.c_str()),
+      .method = strdup(method.c_str()),
       .frameAddress = strdup(frameAddress.c_str()),
       .loadAddress = strdup(loadAddress.c_str()),
       .moduleId = strdup(moduleId.c_str()),
-      .moduleName = strdup(moduleName.c_str())
+      .moduleName = strdup(moduleName.c_str()),
+      .returnAddress = strdup(returnAddress.c_str()),
+      .symbolAddress = strdup(symbolAddress.c_str()),
+      .codeFile = strdup(codeFile.c_str())
     };
     frames.push_back(f);
   }

--- a/src/processor/bugsnag_stackwalk_wrapper.cc
+++ b/src/processor/bugsnag_stackwalk_wrapper.cc
@@ -56,6 +56,34 @@ static Stacktrace getStack(int thread_num, const CallStack* stack)  {
     string returnAddress = HexString(frame->ReturnAddress());
     string symbolAddress = HexString(frame->function_base);
     string codeFile;
+    string trust = "";
+  
+    // TODO: Maybe split this into a function but when I try I get "use of undeclared identifier 'getFrameTrust'" when trying to build
+    switch(frame->trust) {
+      case StackFrame::FRAME_TRUST_NONE:
+        trust = "NONE";
+        break;
+      case StackFrame::FRAME_TRUST_SCAN:
+        trust = "SCAN";
+        break;
+      case StackFrame::FRAME_TRUST_CFI_SCAN:
+        trust = "CFI_SCAN";
+        break;
+      case StackFrame::FRAME_TRUST_FP:
+      trust = "FP";
+      break;
+      case StackFrame::FRAME_TRUST_CFI:
+      trust = "CFI";
+      break;
+      case StackFrame::FRAME_TRUST_PREWALKED:
+      trust = "PREWALKED";
+      break;
+      case StackFrame::FRAME_TRUST_CONTEXT:
+      trust = "CONTEXT";
+      break;
+      default:
+        break;
+    }
 
     if (symbolAddress == "0x0") {
       symbolAddress = "";
@@ -78,7 +106,8 @@ static Stacktrace getStack(int thread_num, const CallStack* stack)  {
       .moduleName = strdup(moduleName.c_str()),
       .returnAddress = strdup(returnAddress.c_str()),
       .symbolAddress = strdup(symbolAddress.c_str()),
-      .codeFile = strdup(codeFile.c_str())
+      .codeFile = strdup(codeFile.c_str()),
+      .trust = strdup(trust.c_str())
     };
     frames.push_back(f);
   }
@@ -199,6 +228,38 @@ WrappedModuleDetails GetModuleDetails(const char* minidump_filename) {
   }
 
   return result;
+}
+
+string getFrameTrust(StackFrame::FrameTrust frameTrust) {
+  string trust = "";
+  
+  switch(frameTrust) {
+    case StackFrame::FRAME_TRUST_NONE:
+      trust = "NONE";
+      break;
+    case StackFrame::FRAME_TRUST_SCAN:
+      trust = "SCAN";
+      break;
+    case StackFrame::FRAME_TRUST_CFI_SCAN:
+      trust = "CFI_SCAN";
+      break;
+    case StackFrame::FRAME_TRUST_FP:
+    trust = "FP";
+    break;
+    case StackFrame::FRAME_TRUST_CFI:
+    trust = "CFI";
+    break;
+    case StackFrame::FRAME_TRUST_PREWALKED:
+    trust = "PREWALKED";
+    break;
+    case StackFrame::FRAME_TRUST_CONTEXT:
+    trust = "CONTEXT";
+    break;
+    default:
+      break;
+  }
+
+  return trust;
 }
 
 // Gets a friendly version of a minidump processing failure reason

--- a/src/processor/bugsnag_stackwalk_wrapper.h
+++ b/src/processor/bugsnag_stackwalk_wrapper.h
@@ -16,6 +16,9 @@ extern "C" {
     const char* loadAddress;
     const char* moduleId;
     const char* moduleName;
+    const char* returnAddress;
+    const char* symbolAddress;
+    const char* codeFile;
 
     void destroy() {
       // TODO ensure that it is not null first (in all of the destroy functions)
@@ -25,6 +28,9 @@ extern "C" {
       free((void *)loadAddress);
       free((void *)moduleId);
       free((void *)moduleName);
+      free((void *)returnAddress);
+      free((void *)symbolAddress);
+      free((void *)codeFile);
     }
   } Stackframe;
 

--- a/src/processor/bugsnag_stackwalk_wrapper.h
+++ b/src/processor/bugsnag_stackwalk_wrapper.h
@@ -19,6 +19,7 @@ extern "C" {
     const char* returnAddress;
     const char* symbolAddress;
     const char* codeFile;
+    const char* trust;
 
     void destroy() {
       // TODO ensure that it is not null first (in all of the destroy functions)
@@ -31,6 +32,7 @@ extern "C" {
       free((void *)returnAddress);
       free((void *)symbolAddress);
       free((void *)codeFile);
+      free((void *)trust);
     }
   } Stackframe;
 


### PR DESCRIPTION
This change adds in 4 new fields (`returnAddress`, `symbolAddress`, `codeFile` and `trust`) and updates the `method` field.

Note: I tried to split the enum switching out to it's own function/method in the same way as the `getFriendlyFailureReason` function in the file, but for some reason when I tried to build I got an error and I have no idea why, hence the TODO. 