### PR TITLE
Fix memory leak

### DIFF
--- a/src/processor/bugsnag_stackwalk_wrapper.h
+++ b/src/processor/bugsnag_stackwalk_wrapper.h
@@ -41,6 +41,9 @@ extern "C" {
     Stackframe* frames;
 
     void destroy() {
+      for (int i = 0; i < frameCount; i++) {
+        frames[i].destroy();
+      }
       free(frames);
     }
   } Stacktrace;
@@ -97,6 +100,10 @@ extern "C" {
     void destroy() {
       app.destroy();
       device.destroy();
+      exception.destroy();
+      for (int i = 0; i < threadCount; i++) {
+        threads[i].destroy();
+      }
       free(threads);
     }
   } Event;


### PR DESCRIPTION
Generated stacktraces currently aren't being cleared down when calling `FreeEvent`

cc @mjc-bugsnag 