### PR TITLE
fix for SIGSEGV when DestroySerializedModuleDetails called without serialized_data

### DIFF
--- a/src/processor/bugsnag_stackwalk_wrapper.cc
+++ b/src/processor/bugsnag_stackwalk_wrapper.cc
@@ -565,6 +565,7 @@ bool SerializeModule(SerializedModuleDetails* stack_module_details) {
     BasicSourceLineResolver resolver;
     scoped_ptr<google_breakpad::CodeModule> code_module(
           new google_breakpad::BasicCodeModule(0, 0, stack_module_details->code_file, "", "", "", ""));
+    
     bool loaded = resolver.LoadModule(code_module.get(), stack_module_details->module_path);
     if (!loaded) {
       BPLOG(ERROR) << "Failed to load Module " << stack_module_details->module_path;
@@ -891,7 +892,7 @@ void DestroyModuleDetails(WrappedModuleDetails* wrapped_module_details) {
 
 // Frees the memory allocated by the serialized module details
 void DestroySerializedModuleDetails(SerializedModuleDetails* serialized_module_details) {
-  if (serialized_module_details) {
+  if (serialized_module_details && serialized_module_details->serialized_data) {
     freeAndInvalidate((void**)&serialized_module_details->serialized_data);
   }
 }

--- a/src/processor/bugsnag_stackwalk_wrapper.cc
+++ b/src/processor/bugsnag_stackwalk_wrapper.cc
@@ -565,7 +565,6 @@ bool SerializeModule(SerializedModuleDetails* stack_module_details) {
     BasicSourceLineResolver resolver;
     scoped_ptr<google_breakpad::CodeModule> code_module(
           new google_breakpad::BasicCodeModule(0, 0, stack_module_details->code_file, "", "", "", ""));
-    
     bool loaded = resolver.LoadModule(code_module.get(), stack_module_details->module_path);
     if (!loaded) {
       BPLOG(ERROR) << "Failed to load Module " << stack_module_details->module_path;


### PR DESCRIPTION
If a call to SerializeModule fails to load or serialize then serialized_data is nullptr. On destroy when trying to free the memory then throws SIGSEGV.

The fix safety checks serialized_data before trying to free memory.