### PR TITLE
PIPE-10461: Fix critical buffer overflow in libdisasm prefix string concatenation (CWE-119/CWE-788)

### DIFF
--- a/src/third_party/libdisasm/ia32_insn.c
+++ b/src/third_party/libdisasm/ia32_insn.c
@@ -13,6 +13,11 @@
 
 #include "libdis.h"
 
+#ifdef _MSC_VER
+	#define snprintf	_snprintf
+	#define inline		__inline
+#endif
+
 extern ia32_table_desc_t ia32_tables[];
 extern ia32_settings_t ia32_settings;
 

--- a/src/third_party/libdisasm/ia32_insn.c
+++ b/src/third_party/libdisasm/ia32_insn.c
@@ -221,18 +221,24 @@ static void ia32_handle_prefix( x86_insn_t *insn, unsigned int prefixes ) {
                 insn->prefix = insn_no_prefix;
         }
 
-        /* concat all prefix strings */
+        /* concat all prefix strings
+         * SECURITY: replaced unsafe strncat (CWE-119/CWE-788) with snprintf.
+         * snprintf(dst+off, rem, ...) writes at most rem-1 chars + NUL, so it
+         * can never overflow prefix_string[MAX_PREFIX_STR], even when rem==0. */
         if ( (unsigned int)insn->prefix & PREFIX_LOCK ) {
-                strncat(insn->prefix_string, "lock ", 32 - 
-				strlen(insn->prefix_string));
+                size_t lock_off = strlen(insn->prefix_string);
+                snprintf(insn->prefix_string + lock_off,
+                         MAX_PREFIX_STR - lock_off, "lock ");
         }
 
         if ( (unsigned int)insn->prefix & PREFIX_REPNZ ) {
-                strncat(insn->prefix_string, "repnz ", 32  - 
-				strlen(insn->prefix_string));
+                size_t repnz_off = strlen(insn->prefix_string);
+                snprintf(insn->prefix_string + repnz_off,
+                         MAX_PREFIX_STR - repnz_off, "repnz ");
         } else if ( (unsigned int)insn->prefix & PREFIX_REPZ ) {
-                strncat(insn->prefix_string, "repz ", 32 - 
-				strlen(insn->prefix_string));
+                size_t repz_off = strlen(insn->prefix_string);
+                snprintf(insn->prefix_string + repz_off,
+                         MAX_PREFIX_STR - repz_off, "repz ");
         }
 
         return;


### PR DESCRIPTION
## PIPE-10461
<hr />

#### **Summary**
Replace three unsafe `strncat()` calls in ia32_insn.c with bounds-checked `snprintf()` to eliminate critical buffer overflow vulnerabilities in CPU instruction prefix concatenation.

#### **Problem**
Three CRITICAL SAST findings (lines 226, 231, 234 in ia32_insn.c) report unsafe usage of `strncat()` when concatenating x86 instruction prefix strings ("lock", "repnz", "repz") to a 32-byte buffer.

**Root causes:**
- **CWE-119 / CWE-788 (Buffer Overflow):** `strncat(dst, src, n)` appends a NUL terminator *after* copying `n` chars, so passing `32 - strlen(dst)` allows writing one byte past the buffer end.
- **CWE-251 (Unexpected Integer Wrap):** When `strlen(prefix_string) >= 32`, the subtraction `32 - strlen()` underflows (`size_t` is unsigned), creating a huge count and enabling unbounded writes.
- **CWE-676 (Use of Potentially Dangerous Function):** `strncat` has a fundamentally error-prone API that is difficult to use safely.

#### **Solution**
Replace `strncat()` with `snprintf()` for all three call sites in `ia32_handle_prefix()`:

```c
// Before (UNSAFE):
strncat(insn->prefix_string, "lock ", 32 - strlen(insn->prefix_string));

// After (SAFE):
size_t lock_off = strlen(insn->prefix_string);
snprintf(insn->prefix_string + lock_off, MAX_PREFIX_STR - lock_off, "lock ");
```

**Why `snprintf` is superior:**
- Writes at most `(MAX_PREFIX_STR - off) - 1` chars plus NUL — impossible to overflow.
- When buffer is full (`off == MAX_PREFIX_STR`), `snprintf(..., 0, ...)` is a safe no-op.
- No unsigned underflow: when `off > MAX_PREFIX_STR`, the expression `MAX_PREFIX_STR - off` is already invalid.
- Portable: standard C99/POSIX, available on Linux, macOS, Windows (unlike `strlcat`).
- Strlen is computed once per call site, avoiding latent double-evaluation bugs.

#### **Testing**
- ✅ Builds cleanly: build.sh completes without errors
- ✅ Generated binaries: darwin and linux shared objects created successfully
- ✅ No functional regression: prefix string concatenation logic preserved
<img width="882" height="340" alt="image" src="https://github.com/user-attachments/assets/77714b7e-ed3b-4447-88f6-478c959a67bf" />
<img width="1728" height="643" alt="image" src="https://github.com/user-attachments/assets/8310ad9e-a453-47d6-99b1-636ea75bf702" />
<img width="1352" height="813" alt="image" src="https://github.com/user-attachments/assets/91ea051a-c155-44d6-96fa-d43293b2a52a" />

