### PR TITLE
PIPE-10426-10447-cpp-vuln-fix

### DIFF
--- a/src/common/windows/symbol_collector_client.cc
+++ b/src/common/windows/symbol_collector_client.cc
@@ -32,7 +32,7 @@ namespace google_breakpad {
         &response,
         &response_code)) {
       wprintf(L"Failed to create upload url.\n");
-      wprintf(L"Response code: %ld\n", response_code);
+      wprintf(L"Response code: %d\n", response_code);
       wprintf(L"Response:\n");
       wprintf(L"%s\n", response.c_str());
       return false;
@@ -111,7 +111,7 @@ namespace google_breakpad {
         &response,
         &response_code)) {
       wprintf(L"Failed to complete upload.\n");
-      wprintf(L"Response code: %ld\n", response_code);
+      wprintf(L"Response code: %d\n", response_code);
       wprintf(L"Response:\n");
       wprintf(L"%s\n", response.c_str());
       return CompleteUploadResult::Error;
@@ -154,7 +154,7 @@ namespace google_breakpad {
         &response,
         &response_code)) {
       wprintf(L"Failed to check symbol status.\n");
-      wprintf(L"Response code: %ld\n", response_code);
+      wprintf(L"Response code: %d\n", response_code);
       wprintf(L"Response:\n");
       wprintf(L"%s\n", response.c_str());
       return SymbolStatus::Unknown;

--- a/src/processor/static_range_map.h
+++ b/src/processor/static_range_map.h
@@ -88,7 +88,7 @@ class StaticRangeMap {
       return *(reinterpret_cast<const AddressType*>(this));
     }
     const EntryType* entryptr() const {
-      return reinterpret_cast<const EntryType*>(this + sizeof(AddressType));
+      return reinterpret_cast<const EntryType*>(reinterpret_cast<const char*>(this) + sizeof(AddressType));
     }
   };
 


### PR DESCRIPTION
Summary
Fixes 2 Wiz SAST findings in bugsnag/breakpad — 1 wrong format specifier (CWE-686) and 1 incorrect pointer scaling (CWE-468).

Jira Tickets
PIPE-10426: SAST Finding | bugsnag/breakpad | src/common/windows/symbol_collector_client.cc
In Progress
 — Wrong format specifier in symbol_collector_client.cc

PIPE-10447: SAST Finding | bugsnag/breakpad | src/processor/static_range_map.h
To Do
 — Incorrect pointer scaling in static_range_map.h

Changes
PIPE-10426 — Format String Fix (src/common/windows/symbol_collector_client.cc)
response_code is declared as int in all 3 functions but passed with %ld which expects long. Fixed by changing %ld → %d in 3 places.

PIPE-10447 — Pointer Scaling Fix (src/processor/static_range_map.h)
this + sizeof(AddressType) performs pointer arithmetic on a Range*. In C++, pointer arithmetic scales by sizeof(Range) not by 1 byte — so this advances way past the intended offset. Fixed by casting this to const char* first to ensure byte-level arithmetic.

Root Cause
CWE-686 (PIPE-10426): %ld expects long but response_code is int. On Windows 64-bit, long and int are different sizes — this causes undefined behaviour in the wprintf call.

CWE-468 (PIPE-10447): C++ pointer arithmetic on Range* scales by sizeof(Range), not by 1 byte. The intended behaviour is to advance by sizeof(AddressType) bytes, which requires casting to char* before the addition.

Testing
No logic changes — format specifier corrections and one pointer cast
Compilation verified — no warnings or errors introduced
Consistent with correct usage patterns elsewhere in the codebase