### PR TITLE
ubuntu-version-test

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   coverity:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       CC: clang
       CXX: clang++
@@ -41,6 +41,7 @@ jobs:
 
     - uses: vapier/coverity-scan-action@v1
       with:
+        project: "Bugsnag breakpad"
         command: make -C src -O -j$(getconf _NPROCESSORS_CONF)
         email: ${{ secrets.COVERITY_SCAN_EMAIL }}
         token: ${{ secrets.COVERITY_SCAN_TOKEN }}


### PR DESCRIPTION
Changes
1. Pin Ubuntu runner to ubuntu-22.04
ubuntu-latest recently upgraded from 22.04 to 24.04, which ships GCC 13 and Clang 18 with stricter compiler diagnostics. This introduced build failures in test compilation that are unrelated to our code changes:

GCC 13: -Werror=stringop-overflow in exception_handler_unittest.cc

Clang 18: missing implicit #include <algorithm> in module.cc

Pinning to ubuntu-22.04 restores the previous build environment while proper code fixes are tracked separately.

2. Set explicit Coverity project name
The vapier/coverity-scan-action defaults to using github.repository (bugsnag/breakpad) as the Coverity project name. However, the registered project name on Coverity's portal is "Bugsnag breakpad" (with a space, no slash). The / character is not valid in Coverity project names, causing token validation to fail with HTTP 401.

Added explicit project: "Bugsnag breakpad" to match the registered project name.

Context
All CI checks were green as of August 4, 2026. Between Aug 4–13, GitHub rolled out new runner images (ubuntu-24.04 image 20260720.247.2) which changed the compiler toolchain. The Coverity issue was a pre-existing misconfiguration that was masked until the token rotation.